### PR TITLE
Allow user to config public registry url

### DIFF
--- a/bower.conf.json
+++ b/bower.conf.json
@@ -2,6 +2,7 @@
     "port": 5678,
     "registryFile": "./bowerRepository.json",
     "disablePublic": false,
+    "publicRegistry": "http://registry.bower.io/packages",
     "repositoryCache": {
         "enabled": false,
         "gitHost": "localhost",

--- a/lib/public-package-store.js
+++ b/lib/public-package-store.js
@@ -6,6 +6,10 @@ var publicBowerUrl = 'http://bower.herokuapp.com/packages/';
 module.exports = function PublicPackageStore(config) {
     var _packages = {};
 
+    if(config.publicRegistry) {
+      publicBowerUrl = config.publicRegistry;
+    }
+
     _init();
     function _init() {
         logger.log('Refreshing public packages...');


### PR DESCRIPTION
In my company default registry url "http://bower.herokuapp.com/packages/" is blocked but mirror 'http://registry.bower.io' is available, so it would be useful to specify a public registry url.

Thanks,
Rick
