### PR TITLE
replaced setInterval by setTimeout

### DIFF
--- a/lib/public-package-store.js
+++ b/lib/public-package-store.js
@@ -10,14 +10,14 @@ module.exports = function PublicPackageStore(config) {
     function _init() {
         logger.log('Refreshing public packages...');
 
-        setInterval(_loadPublicPackages, 1000 * 60 * 30);
+        _loadPublicPackagesPeriodically();
     }
 
     function _getPackage(packageName) {
         return _packages[packageName];
     }
 
-    function _loadPublicPackages() {
+    function _loadPublicPackagesPeriodically() {
         var client = createClient();
 
         client.get(publicBowerUrl, function(data) {
@@ -68,6 +68,9 @@ module.exports = function PublicPackageStore(config) {
 
             return new Client(clientOptions);
         }
+
+        // re-schedule the function
+        setTimeout(_loadPublicPackagesPeriodically, 1000 * 60 * 30);
     }
 
     function _searchPackage(name) {


### PR DESCRIPTION
to prevent waiting for the first loop of setInterval
when the application starts.

The problem with the original version was that on first start of the server, I would have to wait 30 minutes before I can use the private repo for fetching packages from the public repo the first time.
