### PR TITLE
Fixes ENOTFOUND for uncached packages

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -287,7 +287,7 @@ function _initService() {
                     .then(function(pack) {
                         var privatePackage = {
                             name: packageName,
-                            repo: pack.repo,
+                            url: pack.repo,
                             hits: publicPackage.hits
                         };
 


### PR DESCRIPTION
The expected entry in the response is "url", not "repo" (compare to https://github.com/oliversalzburg/private-bower/blob/778b2fb51bf624345294507fbc27e79bbd477596/lib/server.js#L266)

Also see: https://github.com/bower/registry-client/blob/master/lib/lookup.js#L118

Fixes #15, #74
