### PR TITLE
Previous commit didn't move fs import

### DIFF
--- a/lib/repo-caches/git-repo-cache.js
+++ b/lib/repo-caches/git-repo-cache.js
@@ -3,6 +3,7 @@ var q = require('q');
 var path = require('path');
 var logger = require('./../logger');
 var mkdirp = require('mkdirp');
+var fs = require('fs');
 var exec = require('child_process').exec;
 
 var RepoCacheBase = require('./repo-cache-base');


### PR DESCRIPTION
`_getLatestForRepos` is now in `git-repo-cache`, but the `require('fs')` was missing.
