### PR TITLE
Ignore/discard all local changes before pulling updates

### DIFF
--- a/lib/repo-caches/git-repo-cache.js
+++ b/lib/repo-caches/git-repo-cache.js
@@ -1,4 +1,4 @@
-require('./../utils');
+var utils = require('./../utils');
 var q = require('q');
 var path = require('path');
 var logger = require('./../logger');
@@ -156,21 +156,26 @@ module.exports = function GitRepoCache(options) {
             var packageDirPath = path.join(options.repoCacheRoot, packageDirectory);
 
             if(fs.existsSync(packageDirPath)) {
-                process.chdir(packageDirPath);
-
-                exec('git pull', function(error, stdout, stderr) {
-                    if(error) {
-                        logger.log('Error during "git pull" in ' + packageDirectory);
-                        logger.error(error.message);
-
-                        deferred.reject(stderr);
-                        return;
-                    }
-
-                    logger.log('Pulled latest for {0}'.format(path.basename(packageDirectory)));
-
-                    deferred.resolve();
-                });
+                // Update the local repository to the latest version from origin.
+                utils.exec('git fetch --prune --tags', packageDirPath)
+                    .then(function() {
+                        // Reset the current local master to the identical state from origin.
+                        return utils.exec('git reset --hard origin/master', packageDirPath);
+                    })
+                    .then(function() {
+                        // Pull the latest master changes from origin into the local master.
+                        return utils.exec('git pull', packageDirPath);
+                    })
+                    .then(function() {
+                        logger.log('Pulled latest for {0}'.format(path.basename(packageDirectory)));
+                        deferred.resolve();
+                    })
+                    .catch(function(error) {
+                        if(error && error.message) {
+                            logger.error(error.message)
+                        }
+                        deferred.reject(error);
+                    });
             }
             else {
                 logger.log('Could not pull latest, because "{0}" directory cannot be found'.format(packageDirPath));

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,8 @@
+var exec = require('child_process').exec;
 var fs = require('fs');
+var logger = require('./logger');
 var path = require('path');
+var q = require('q');
 
 module.exports = function Utils() {
     _init();
@@ -50,7 +53,25 @@ module.exports = function Utils() {
         fs.rmdirSync(dirPath);
     }
 
+    function _exec(command, cwd) {
+        var deferred = q.defer();
+
+        process.chdir(cwd);
+        exec(command, function(error, stdout, stderr) {
+            if(error) {
+                logger.log('Error during "{0}" in "{1}"'.format(command,cwd));
+                deferred.reject(error);
+                return;
+            }
+
+            deferred.resolve();
+        });
+
+        return deferred.promise;
+    }
+
     return {
+        exec: _exec,
         getChildDirectories: _getChildDirectories,
         removeDirectory: _removeDirectory
     };


### PR DESCRIPTION
The local master is now reset to the origin master before attempting to pull changes. This solves issues when "history has been rewritten" in public repositories.

Closes #91
