### PR TITLE
Use cwd option for child process

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -56,8 +56,7 @@ module.exports = function Utils() {
     function _exec(command, cwd) {
         var deferred = q.defer();
 
-        process.chdir(cwd);
-        exec(command, function(error, stdout) {
+        exec(command, {cwd: cwd}, function(error, stdout) {
             if(error) {
                 logger.log('Error during "{0}" in "{1}"'.format(command,cwd));
                 deferred.reject(error);


### PR DESCRIPTION
I noticed that [`child_process.exec` has a `cwd` field in the optional `options` argument](http://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback).

This change makes use of that option instead of changing the working directory for the parent process.

Please note that I came across this while porting `utils._exec` to my own application. I wasn't able to test if this change has any implications on how private-bower works.