### PR TITLE
Load public packages json from cache in case of server or network problem

### DIFF
--- a/bower.conf.json
+++ b/bower.conf.json
@@ -1,6 +1,7 @@
 {
     "port": 5678,
     "registryFile": "./bowerRepository.json",
+    "registryFilePublic": "./bowerRepositoryPublic.json",
     "timeout": 144000,
     "disablePublic": false,
     "publicRegistry": "http://bower.herokuapp.com/packages/",

--- a/lib/public-package-store.js
+++ b/lib/public-package-store.js
@@ -1,5 +1,6 @@
 var logger = require('./logger');
 var Client = require('node-rest-client').Client;
+var fs = require('fs');
 
 module.exports = function PublicPackageStore(config) {
     var _packages = {};
@@ -9,12 +10,24 @@ module.exports = function PublicPackageStore(config) {
     _init();
     function _init() {
         logger.log('Refreshing public packages...');
-
+        if(fs.existsSync(config.registryFilePublic)) {
+          _parsePackage(fs.readFileSync(config.registryFilePublic));
+          logger.log("Cached public packages loaded");
+        }
+        
         _loadPublicPackagesPeriodically();
     }
 
     function _getPackage(packageName) {
         return _packages[packageName];
+    }
+    
+    function _parsePackage(data) {
+        var jsonData = JSON.parse(data);
+        for(var i = 0, len = jsonData.length; i < len; i++) {
+            var item = jsonData[i];
+            _packages[item.name] = item;
+        }
     }
 
     function _loadPublicPackagesPeriodically() {
@@ -31,23 +44,15 @@ module.exports = function PublicPackageStore(config) {
         });
 
         function processData(data) {
-            if(data.indexOf('Not Found') !== -1) {
-                return;
-            }
-
             try {
-                var jsonData = JSON.parse(data);
-
-                for(var i = 0, len = jsonData.length; i < len; i++) {
-                    var item = jsonData[i];
-
-                    _packages[item.name] = item;
-                }
-
+                _parsePackage(data);
+                fs.writeFile(config.registryFilePublic, data, function(err) {
+                  logger.log(err ? 'Error cache public package' : 'public package cached');
+                });
                 logger.log('Loaded public packages');
 
             } catch (e) {
-                logger.error('Could not load public packages');
+                logger.error('Could not load public packages: data=' + data);
             }
         }
 


### PR DESCRIPTION
I noticed "bower.herokuapp.com" is not unstable, it will down and return "Application Error" often. In that case, when start private-bower, it will just show "Could not load public packages". We will be blocked to use bower command at all. This pull request will cache the package json file locally. If there's the server or network problem, we will just load from the cache file as a backup. 