### PR TITLE
Fixing privatePackageStore.loadPackages

### DIFF
--- a/lib/service/packageStores/privatePackageStore.js
+++ b/lib/service/packageStores/privatePackageStore.js
@@ -97,11 +97,11 @@ module.exports = function PackageStore() {
             throw e;
         }
 
-        function modifyRepoProperty(packageArray) {
+        function modifyRepoProperty(packages) {
             var loadedPackages = [];
 
-            for(var i = 0, len = packageArray.length; i < len; i++) {
-                var pack = packageArray[i];
+            for(var key in packages) {
+                var pack = packages[key];
 
                 loadedPackages.push({
                     name: pack.name,


### PR DESCRIPTION
The helper function modifyRepoProperty expected an array but got an
object. That caused the server to forget all registered packages on
restart.