### PR TITLE
Added 'option' to start git and svn daemon without hostname.

### DIFF
--- a/lib/infrastructure/configurationManager.js
+++ b/lib/infrastructure/configurationManager.js
@@ -51,7 +51,7 @@ module.exports = function ConfigurationManager() {
             if(self.config.repositoryCache.svn && self.config.repositoryCache.svn.enabled) {
                 self.config.repoCacheOptions.svn = {
                     repoCacheRoot: getRelativeFilePath(self.config.repositoryCache.svn.cacheDirectory || './svnRepoCache'),
-                    hostName: self.config.repositoryCache.svn.host || 'localhost',
+                    hostName: self.config.repositoryCache.svn.host,
                     port: self.config.repositoryCache.svn.port || 7891,
                     refreshTimeout: self.config.repositoryCache.svn.refreshTimeout || 10,
                     parameters: self.config.repositoryCache.svn.parameters
@@ -61,7 +61,7 @@ module.exports = function ConfigurationManager() {
             if(self.config.repositoryCache.git && self.config.repositoryCache.git.enabled) {
                 self.config.repoCacheOptions.git = {
                     repoCacheRoot: getRelativeFilePath(self.config.repositoryCache.git.cacheDirectory || './gitRepoCache'),
-                    hostName: self.config.repositoryCache.git.host || 'localhost',
+                    hostName: self.config.repositoryCache.git.host,
                     publicAccessURL: self.config.repositoryCache.git.publicAccessURL || null,
                     port: self.config.repositoryCache.git.port || 6789,
                     refreshTimeout: self.config.repositoryCache.git.refreshTimeout || 10,

--- a/lib/service/repoCaches/gitRepoCache.js
+++ b/lib/service/repoCaches/gitRepoCache.js
@@ -87,8 +87,11 @@ module.exports = function GitRepoCache(options) {
         return new Promise(function(resolve, reject) {
             var customParameters = base.generateCustomParameters();
 
-            var gitCommand = 'git daemon --reuseaddr --base-path="{0}" --listen={1} --port={2} --export-all{3}'
-                .format(options.repoCacheRoot, options.hostName, options.port, customParameters);
+            var gitCommand = 'git daemon --reuseaddr --base-path="{0}" --listen={1} --port={2} --export-all{3}';
+            if (!options.hostName) {
+                gitCommand = 'git daemon --reuseaddr --base-path="{0}" --port={2} --export-all{3}';
+            }
+            gitCommand = gitCommand.format(options.repoCacheRoot, options.hostName, options.port, customParameters);
 
             logger.log('Starting git cache server');
 

--- a/lib/service/repoCaches/svnRepoCache.js
+++ b/lib/service/repoCaches/svnRepoCache.js
@@ -74,8 +74,12 @@ module.exports = function SvnRepoCache(options) {
         return new Promise(function(resolve, reject) {
             var customParameters = base.generateCustomParameters();
 
-            var svnCommand = 'svnserve -d --foreground -r "{0}" --listen-host {1} --listen-port {2}{3}'
-                .format(options.repoCacheRoot, options.hostName, options.port, customParameters);
+            var svnCommand = 'svnserve -d --foreground -r "{0}" --listen-host {1} --listen-port {2}{3}';
+            if (!options.hostName) {
+                svnCommand = 'svnserve -d --foreground -r "{0}" --listen-port {2}{3}';
+            }
+
+            svnCommand = svnCommand.format(options.repoCacheRoot, options.hostName, options.port, customParameters);
 
             logger.log('Starting svn cache server');
 


### PR DESCRIPTION
By leaving the `repositoryCache.(git|svn).host` option empty in the config file, one can now start the git and svn cache daemons without a specified `--listen` hostname.

This solves an issue with running the private-bower registry in a Docker container where it needs to bind to `localhost`, causing `Connection refused` errors when external clients try to use the private-bower repository cache.