### PR TITLE
Adds hostname to repository connection.

### DIFF
--- a/lib/service/packageStores/publicPackageStore.js
+++ b/lib/service/packageStores/publicPackageStore.js
@@ -2,6 +2,7 @@ var fs = require('fs');
 var logger = require('../../infrastructure/logger');
 var Client = require('node-rest-client').Client;
 var config = require('../../infrastructure/configurationManager').config;
+var URI = require('URIjs');
 
 module.exports = function PublicPackageStore() {
     var _packages = {};
@@ -72,7 +73,17 @@ module.exports = function PublicPackageStore() {
     function _loadPublicPackagesPeriodically() {
         var client = createClient();
 
-        client.get(_publicBowerUrl, function(data) {
+        var url = new URI(_publicBowerUrl);
+        // set content-type header and data as json in args parameter
+        var args = {
+            headers:{
+                "Content-Type": "application/json",
+                'host': url.hostname()
+            }
+        };
+
+
+        client.get(_publicBowerUrl, args, function(data) {
             processData(data);
         }).on('error', function(err) {
             logger.error('something went wrong on the request', err.request.options);

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "moment": "^2.7.0",
     "node-rest-client": "^1.0.0",
     "optimist": "^0.5.2",
-    "path-is-absolute": "^1.0.0"
+    "path-is-absolute": "^1.0.0",
+    "URIjs": "^1.5.0"
   },
   "devDependencies": {
     "chai": "^2.2.0",


### PR DESCRIPTION
Fix for the regression-bug https://github.com/Hacklone/private-bower/issues/135

Adds the missing header that is expected by the public bower repository.

It pretty much generic and basically does what was already being done before the last major release of private-bower from HTTP header perspective. Therefore I think its backwards compatible and should work just the same than before.
