### PR TITLE
Fixing JSON auto parsing issue and freezing lib version

### DIFF
--- a/lib/service/packageStores/publicPackageStore.js
+++ b/lib/service/packageStores/publicPackageStore.js
@@ -24,9 +24,8 @@ module.exports = function PublicPackageStore() {
         return _packages[packageName];
     }
 
-    function _parsePackage(data) {
+    function _parsePackage(jsonData) {
         try {
-            var jsonData = JSON.parse(data);
 
             for(var i = 0, len = jsonData.length; i < len; i++) {
                 var item = jsonData[i];
@@ -60,7 +59,9 @@ module.exports = function PublicPackageStore() {
             return;
         }
 
-        fs.writeFile(config.public.registryFile, data, function(err) {
+        var jsonString = JSON.stringify(data);
+
+        fs.writeFile(config.public.registryFile, jsonString, function(err) {
             if(err) {
                 logger.error('Error caching public registry', err);
             }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "log4js": "^0.6.14",
     "mkdirp": "0.5.x",
     "moment": "^2.7.0",
-    "node-rest-client": "^1.0.0",
+    "node-rest-client": "1.5.1",
     "optimist": "^0.5.2",
     "path-is-absolute": "^1.0.0",
     "URIjs": "^1.5.0"


### PR DESCRIPTION
In some recent version of node-rest-client is client automatically
parsing JSON into Object which then result with [object Object] error