### PR TITLE
fix/bufferErrorOnPublicStore

### DIFF
--- a/lib/service/packageStores/publicPackageStore.js
+++ b/lib/service/packageStores/publicPackageStore.js
@@ -88,6 +88,10 @@ module.exports = function PublicPackageStore() {
 
 
         client.get(_publicBowerUrl, args, function(data) {
+            // some requests will end up with the data as a Buffer, instead of string
+            // if the buffer is written to the public package store, then it won't contain
+            // usable data, this will convert data to a string if it is a buffer
+            data = Buffer.isBuffer(data)?data.toString('utf8'):data;
             processData(data);
         }).on('error', function(err) {
             logger.error('something went wrong on the request', err.request.options);


### PR DESCRIPTION
some requests will end up with the data as a Buffer, instead of string if the buffer is written to the public package store, then it won't contain usable data, this will convert data to a string if it is a buffer