### PR TITLE
Updated error message in Utils.exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,10 @@ Must be a valid JSON
 #Usage
 
 ##Web interface
-Convenient way for viewing your packages in a browser
+Convenient way for viewing your packages in a browser.  The web interface will only list your private packages, it will 
+not list the public packages if you have a public registry enabled.  However, when searching for packages in bower, the 
+public ones will show up just fine.
+   
 > http://localhost:5678/
 
 ##Project

--- a/lib/infrastructure/utils.js
+++ b/lib/infrastructure/utils.js
@@ -56,9 +56,10 @@ module.exports = function Utils() {
 
     function _exec(command, cwd) {
         return new Promise(function(resolve, reject) {
-            exec(command, {cwd: cwd}, function(error, stdout) {
+            exec(command, {cwd: cwd}, function(error, stdout, stderr) {
                 if(error) {
-                    logger.log('Error during "{0}" in "{1}". Output was: {2}'.format(command, cwd, stdout));
+                    logger.log('Error during "{0}" in "{1}".');
+                    logger.log('Output was: {2}'.format(command, cwd, stderr));
 
                     reject(error);
                 }

--- a/lib/service/packageStores/publicPackageStore.js
+++ b/lib/service/packageStores/publicPackageStore.js
@@ -88,6 +88,10 @@ module.exports = function PublicPackageStore() {
 
 
         client.get(_publicBowerUrl, args, function(data) {
+            // some requests will end up with the data as a Buffer, instead of string
+            // if the buffer is written to the public package store, then it won't contain
+            // usable data, this will convert data to a string if it is a buffer
+            data = Buffer.isBuffer(data)?data.toString('utf8'):data;
             processData(data);
         }).on('error', function(err) {
             logger.error('something went wrong on the request', err.request.options);


### PR DESCRIPTION
the callback function for exec accepts 3 arguments, added 3rd argument (stderr), which is where a command line program would typically output the error.  Also, for clarity, output the error on a second line.