### PR TITLE
Updated Error message in Utils.exec

### DIFF
--- a/lib/infrastructure/utils.js
+++ b/lib/infrastructure/utils.js
@@ -58,8 +58,9 @@ module.exports = function Utils() {
         return new Promise(function(resolve, reject) {
             exec(command, {cwd: cwd}, function(error, stdout, stderr) {
                 if(error) {
-                    logger.log('Error during "{0}" in "{1}".');
-                    logger.log('Output was: {2}'.format(command, cwd, stderr));
+                    logger.log('Error during "{0}" in "{1}".'.format(command, cwd));
+                    logger.log('Output:  stdout: {0}'.format(stdout));
+                    logger.log('         stderr: {0}'.format(stderr));
 
                     reject(error);
                 }

--- a/lib/infrastructure/utils.js
+++ b/lib/infrastructure/utils.js
@@ -56,9 +56,10 @@ module.exports = function Utils() {
 
     function _exec(command, cwd) {
         return new Promise(function(resolve, reject) {
-            exec(command, {cwd: cwd}, function(error, stdout) {
+            exec(command, {cwd: cwd}, function(error, stdout, stderr) {
                 if(error) {
-                    logger.log('Error during "{0}" in "{1}". Output was: {2}'.format(command, cwd, stdout));
+                    logger.log('Error during "{0}" in "{1}".');
+                    logger.log('Output was: {2}'.format(command, cwd, stderr));
 
                     reject(error);
                 }


### PR DESCRIPTION
the callback function for exec accepts 3 arguments, added 3rd argument (stderr), which is where a command line program would typically output the error.  Also, for clarity, output the error on a second line.