### PR TITLE
Introduce mktmpdir, use it.

### DIFF
--- a/lib/infrastructure/utils.js
+++ b/lib/infrastructure/utils.js
@@ -1,4 +1,5 @@
 var fs = require('fs');
+var os = require('os');
 var path = require('path');
 var logger = require('./logger');
 var Promise = require('bluebird');
@@ -104,12 +105,31 @@ module.exports = function Utils() {
         return Math.random().toString(36).substring(2);
     }
 
+    function _mktmpdir(prefix) {
+        prefix = (prefix || '') + '-' + process.pid + '-';
+
+        var maxTries = 5;
+        for(var i = 0; i < maxTries; ++i) {
+            try {
+                var p = path.join(os.tmpdir(), prefix + _getRandomString());
+                fs.mkdirSync(p, 0700);
+                return p;
+            } catch(e) {
+                if(e.code != 'EEXIST') {
+                    throw e;
+                }
+            }
+        }
+        throw new Error('Could not create a temporary directory after ' + maxTries + ' attempts');
+    }
+
     return {
         exec: _exec,
         extend: _extend,
         process: process,
         getRandomString: _getRandomString,
         dirname: path.join(__dirname, '../'),
+        mktmpdir: _mktmpdir,
         removeDirectory: _removeDirectory,
         getChildDirectories: _getChildDirectories,
         startDetachedChildProcess: _startDetachedChildProcess

--- a/lib/service/packageDetailsProvider.js
+++ b/lib/service/packageDetailsProvider.js
@@ -6,7 +6,7 @@ var Promise = require('bluebird');
 var utils = require('../infrastructure/utils');
 
 module.exports = function PackageDetailsProvider() {
-    var tempFolder = path.join(utils.dirname, 'temp/packageDetails');
+    var tempFolder = path.join(utils.mktmpdir('bower'), 'temp/packageDetails');
     
     function _getPackageDetails(packageUrl) {
         return new Promise(function(resolve, reject) {


### PR DESCRIPTION
Introduce a helper function to create a temporary directory, and use it in `PackageDetailsProvider` to avoid the latter creating temporary directories directly where the script resides in (which can be `/usr/lib/node_modules` when private-bower is installed globally on Ubuntu)

Fixing https://github.com/Hacklone/private-bower/issues/196.

(Several packages offers `mktmpdir`, but I preferred to implement it here instead of adding a new dependency. Max number of tries, i.e. 5 is completely arbitrary)