### PR TITLE
Support unvalued options for git/svn daemons.

### DIFF
--- a/lib/service/repoCaches/repoCacheBase.js
+++ b/lib/service/repoCaches/repoCacheBase.js
@@ -56,7 +56,10 @@ module.exports = function RepoCacheBase(options) {
 
         for(var prop in options.parameters) {
             if(options.parameters.hasOwnProperty(prop)) {
-                customParameters += ' --{0}={1}'.format(prop, options.parameters[prop]);
+                customParameters += ' --{0}'.format(prop);
+                if(options.parameters[prop] !== '') {
+                    customParameters += '={0}'.format(options.parameters[prop]);
+                }
             }
         }
 


### PR DESCRIPTION
Several options of git/svn daemons are not expecting any value,
and no "=" should be appended to the mnemonic when used.

Note that the way to identify such a parameter is tricky and
debatable. The choice made here is to consider empty strings as a
marker for unvalued parameters. To give an actual empty string to
a parameter, a string with a space can still be used.

For example the following configuration:

{
    ...
    "repositoryCache": {
        "git": {
            "foo": " "
            "verbose": "",
            "syslog": "",
            "max-connections": 42
        }
    }
}

Would make private-bower invoke the git daemon as follows:
  git-daemon --foo=  --verbose --syslog --max-connections=42

(Notice the two spaces after "--foo=", effectively giving an empty
value to the "foo" parameter)

Fixes https://github.com/Hacklone/private-bower/issues/200.