### PR TITLE
private-bower sometimes fails to refresh certain cached repositories …

### DIFF
--- a/lib/service/repoCaches/gitRepoCache.js
+++ b/lib/service/repoCaches/gitRepoCache.js
@@ -131,7 +131,6 @@ module.exports = function GitRepoCache(options) {
                 if(fs.existsSync(packageDirPath)) {
                     fetchRepository()
                         .then(hardResetRepository)
-                        .then(pullRepository)
                         .then(function() {
                             logger.log('Pulled latest for {0}'.format(path.basename(packageDirectory)));
                             resolve();
@@ -155,11 +154,7 @@ module.exports = function GitRepoCache(options) {
             }
 
             function hardResetRepository() {
-                return utils.exec('git reset --hard', packageDirPath);
-            }
-
-            function pullRepository() {
-                return utils.exec('git pull', packageDirPath);
+                return utils.exec('git reset --hard origin/master', packageDirPath);
             }
         }
     }


### PR DESCRIPTION
…due to merge conflicts. These come from forced changes of the source repository head. Since we don't need to have a straight commit line anyways, we can simply hard reset the head to origin/master. Fixes #171