### PR TITLE
Invalid JSON in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Must be a valid JSON
     "server": {
         "port": 5678,
         "hostName": null,
-        "siteBaseUrl": null,
+        "siteBaseUrl": null
     },
     "public": {
         "disabled": false,


### PR DESCRIPTION
```javascript
"server": {
        "port": 5678,
        "hostName": null,
        "siteBaseUrl": null,
    },
```
Comma after siteBaseUrl become the json invalid, just lost couple of minutes using it direct from example.