### PR TITLE
Check if _listeningServer exists before call method .close

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -66,9 +66,10 @@ module.exports = function Application() {
 
     function _shutDown() {
         logger.log('Shutting down private-bower');
-
-        _listeningServer.close();
-
+        if(_listeningServer){
+            _listeningServer.close();
+        }
+        
         publicPackageStore.shutDown();
 
         if(_repoCacheHandler) {


### PR DESCRIPTION
If some error occurred before start the server e.g (an invalid config file), you can't see the error message because _listeningServer will be undefined and this line will throw a code error.