### PR TITLE
Creating two providers to read details

### DIFF
--- a/lib/service/gitPackageDetailsProvider.js
+++ b/lib/service/gitPackageDetailsProvider.js
@@ -1,0 +1,34 @@
+
+var fs = require('fs');
+var path = require('path');
+var Promise = require('bluebird');
+
+var utils = require('../infrastructure/utils');
+
+module.exports = function GitPackageDetailsProvider() {
+    var tempFolder = path.join(utils.dirname, 'temp/packageDetails');
+
+    function _getPackageDetails(packageUrl) {
+        return new Promise(function(resolve, reject) {
+            var tempName = utils.getRandomString();
+            var gitCloneFolder = path.join(tempFolder, tempName);
+
+            utils.exec('git clone {0} {1} --depth=1'.format(packageUrl, gitCloneFolder))
+                .then(function() {
+                    var bowerJsonLocation = path.join(gitCloneFolder, 'bower.json');
+
+                    var fileContent = fs.readFileSync(bowerJsonLocation);
+                    var bowerJson = JSON.parse(fileContent);
+
+                    utils.removeDirectory(gitCloneFolder);
+
+                    resolve(bowerJson);
+                })
+                .catch(reject);
+        });
+    }
+
+    return {
+        getPackageDetails: _getPackageDetails
+    };
+}();

--- a/lib/service/packageDetailsProvider.js
+++ b/lib/service/packageDetailsProvider.js
@@ -3,31 +3,20 @@ var fs = require('fs');
 var path = require('path');
 var Promise = require('bluebird');
 
+var GitPackageDetailsProvider = require('./gitPackageDetailsProvider');
+var SvnPackageDetailsProvider = require('./svnPackageDetailsProvider');
+
 var utils = require('../infrastructure/utils');
 
 module.exports = function PackageDetailsProvider() {
-    var tempFolder = path.join(utils.dirname, 'temp/packageDetails');
-    
+
     function _getPackageDetails(packageUrl) {
-        return new Promise(function(resolve, reject) {
-            var tempName = utils.getRandomString();
-            var gitCloneFolder = path.join(tempFolder, tempName);
-            
-            utils.exec('git clone {0} {1} --depth=1'.format(packageUrl, gitCloneFolder))
-                .then(function() {
-                    var bowerJsonLocation = path.join(gitCloneFolder, 'bower.json');
-                    
-                    var fileContent = fs.readFileSync(bowerJsonLocation);
-                    var bowerJson = JSON.parse(fileContent);
-                    
-                    utils.removeDirectory(gitCloneFolder);
-                    
-                    resolve(bowerJson);
-                })
-                .catch(reject);
-        });
+        if(packageUrl.substring(0, 4) === 'svn+') {
+            return SvnPackageDetailsProvider.getPackageDetails(packageUrl);
+        }
+        return GitPackageDetailsProvider.getPackageDetails(packageUrl);
     }
-    
+
     return {
         getPackageDetails: _getPackageDetails
     };

--- a/lib/service/repoCaches/svnRepoCache.js
+++ b/lib/service/repoCaches/svnRepoCache.js
@@ -99,6 +99,11 @@ module.exports = function SvnRepoCache(options) {
     function _cloneSvnRepo(repoUrl, packageDirectory, repoName) {
         logger.log('Cloning {0} ...'.format(repoName));
 
+        // remove string 'svn+' if isn't 'ssh' url.
+        if (repoUrl.indexOf('ssh://') == -1) {
+            repoUrl = repoUrl.replace('svn+', '');
+        }
+
         var svnCommand = 'svn co {0} ./'.format(repoUrl);
 
         return utils.exec(svnCommand, packageDirectory)

--- a/lib/service/svnPackageDetailsProvider.js
+++ b/lib/service/svnPackageDetailsProvider.js
@@ -1,0 +1,46 @@
+
+var fs = require('fs');
+var path = require('path');
+var Promise = require('bluebird');
+
+var utils = require('../infrastructure/utils');
+
+module.exports = function SvnPackageDetailsProvider() {
+    var tempFolder = path.join(utils.dirname, 'temp/packageDetails');
+
+    function _getPackageDetails(packageUrl) {
+        return new Promise(function(resolve, reject) {
+            var tempName = utils.getRandomString();
+            var svnCloneFolder = path.join(tempFolder, tempName);
+
+            // remove string 'svn+' if isn't 'ssh' url.
+            if (packageUrl.indexOf('ssh://') == -1) {
+                packageUrl = packageUrl.replace('svn+', '');
+            }
+
+            // set to trunk to get the info.
+            if (packageUrl.slice(-1) === '/') {
+                packageUrl = packageUrl + 'trunk';
+            } else {
+                packageUrl = packageUrl + '/trunk';
+            }
+
+            utils.exec('svn co {0} {1} --depth files'.format(packageUrl, svnCloneFolder))
+                .then(function() {
+                    var bowerJsonLocation = path.join(svnCloneFolder, 'bower.json');
+
+                    var fileContent = fs.readFileSync(bowerJsonLocation);
+                    var bowerJson = JSON.parse(fileContent);
+
+                    utils.removeDirectory(svnCloneFolder);
+
+                    resolve(bowerJson);
+                })
+                .catch(reject);
+        });
+    }
+
+    return {
+        getPackageDetails: _getPackageDetails
+    };
+}();


### PR DESCRIPTION
Dividing the 'packageDetailsProvider.js' in two providers:
'gitPackageDetailsProvider.js' and 'svnPackageDetailsProvider.js' to
read the info  from bower.json from svn.