### PR TITLE
Add svn support for package details

### DIFF
--- a/lib/service/packageDetailsProvider.js
+++ b/lib/service/packageDetailsProvider.js
@@ -1,6 +1,7 @@
 
 var fs = require('fs');
 var path = require('path');
+var url = require('url');
 var Promise = require('bluebird');
 
 var utils = require('../infrastructure/utils');
@@ -11,19 +12,39 @@ module.exports = function PackageDetailsProvider() {
     function _getPackageDetails(packageUrl) {
         return new Promise(function(resolve, reject) {
             var tempName = utils.getRandomString();
-            var gitCloneFolder = path.join(tempFolder, tempName);
-            
-            utils.exec('git clone {0} {1} --depth=1'.format(packageUrl, gitCloneFolder))
-                .then(function() {
-                    var bowerJsonLocation = path.join(gitCloneFolder, 'bower.json');
-                    
-                    var fileContent = fs.readFileSync(bowerJsonLocation);
-                    var bowerJson = JSON.parse(fileContent);
-                    
-                    utils.removeDirectory(gitCloneFolder);
-                    
-                    resolve(bowerJson);
-                })
+            var targetFolder = path.join(tempFolder, tempName);
+
+            var successHandler = function() {
+                var bowerJsonLocation = path.join(targetFolder, 'bower.json');
+
+                var fileContent = fs.readFileSync(bowerJsonLocation);
+                var bowerJson = JSON.parse(fileContent);
+
+                utils.removeDirectory(targetFolder);
+
+                resolve(bowerJson);
+            };
+
+            var parsedUrl = url.parse(packageUrl);
+            var cloneUrl = packageUrl;
+            var tool;
+
+            var protocolSep = parsedUrl.protocol.indexOf('+');
+
+            if (protocolSep > -1) {
+                tool = cloneUrl.substring(0, protocolSep);
+                cloneUrl = cloneUrl.substring(protocolSep + 1);
+            }
+
+            var execCommand;
+            if (tool == 'svn') {
+                execCommand = 'svn co {0}/trunk {1} --depth=immediates'.format(cloneUrl, targetFolder);
+            } else {
+                execCommand = 'git clone {0} {1} --depth=1'.format(cloneUrl, targetFolder);
+            }
+
+            utils.exec(execCommand)
+                .then(successHandler)
                 .catch(reject);
         });
     }


### PR DESCRIPTION
Add support for viewing package details hosted in svn, with urls structured like ```svn+http://...```. It also supports URLs of git repositories starting with `git+`, like `git+ssh://`

This requires svn command line client to be installed on the host.