### PR TITLE
Change way of removing temp files

### DIFF
--- a/lib/infrastructure/utils.js
+++ b/lib/infrastructure/utils.js
@@ -4,6 +4,7 @@ var logger = require('./logger');
 var Promise = require('bluebird');
 var exec = require('child_process').exec;
 var spawn = require('child_process').spawn;
+var rmdir = require('rimraf');
 
 module.exports = function Utils() {
     _init();
@@ -36,22 +37,11 @@ module.exports = function Utils() {
     }
 
     function _removeDirectory(dirPath) {
-        if(!fs.existsSync(dirPath)) {
-            return;
-        }
-
-        fs.readdirSync(dirPath).forEach(function(file) {
-            var currentFilePathPath = path.join(dirPath, file);
-
-            if(fs.lstatSync(currentFilePathPath).isDirectory()) {
-                _removeDirectory(currentFilePathPath);
-            }
-            else {
-                fs.unlinkSync(currentFilePathPath);
+        rmdir(dirPath, function(error) {
+            if(error) {
+               logger.log(error);
             }
         });
-
-        fs.rmdirSync(dirPath);
     }
 
     function _exec(command, cwd) {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "run-sequence": "^1.0.2",
     "sinon": "^1.14.1",
     "sinon-chai": "^2.7.0",
-    "superagent": "^1.1.0"
+    "superagent": "^1.1.0",
+	"rimraf": "^2.5.2"
   },
   "bugs": {
     "url": "https://github.com/Hacklone/private-bower/issues"


### PR DESCRIPTION
Hi, 
I got: "Failed to load package details! (Your private-bower server needs read access to this Git repository and the git repository must contain a bower.json file!)" when I want download details about package. 
I debugged this and I found that plugin throw exception when want remove temp directory. It's throws exception when plugin want to remove directory: "02" because it's take file "b8d3f903a9e5a58ed9e48fc5a36002ce5c30d3" as directory, but it's file without extension.
my sample path: "temp\packageDetails\cfmapb453p5bfbt9.git\objects\02\b8d3f903a9e5a58ed9e48fc5a36002ce5c30d3"