### PR TITLE
Support new refreshDisabled setting for git and svn repository caches

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,9 @@ Must be a valid JSON
             "host": "localhost",
             "port": 6789,
             "protocol": "git",
-            "publicAccessURL" : null,
-            "refreshTimeout": 10
+            "publicAccessURL": null,
+            "refreshTimeout": 10,
+            "refreshDisabled": false
         },
         "svn": {
             "enabled": false,
@@ -112,21 +113,22 @@ Must be a valid JSON
             "host": "localhost",
             "port": 7891,
             "protocol": "svn",
-            "publicAccessURL" : null,
-            "refreshTimeout": 10
+            "publicAccessURL": null,
+            "refreshTimeout": 10,
+            "refreshDisabled": false
         }
     },
     "proxySettings" : {
         "enabled": false,
         "host": "proxy",
         "username": "name",
-        "password" : "pass",
+        "password": "pass",
         "port": 8080,
         "tunnel": false
     },
     "log4js" : {
         "enabled": false,
-        "configPath" : "log4js.conf.json"
+        "configPath": "log4js.conf.json"
     }
 }
 ```
@@ -137,7 +139,7 @@ Must be a valid JSON
 | server.hostName                            | Host name on which the private bower server will listen                              | null (process.env.IP if set)          |
 | server.siteBaseUrl                         | Load private bower server on a specific path, useful for using a reverse proxy       | null                                  |
 | registryFile                               | File for persisting private packages (must be a valid json)                          | ./bowerRepository.json                |
-| timeout                                    | server package timeout                                                               | 144 000                               |
+| timeout                                    | Server package timeout                                                               | 144 000                               |
 | public.disabled                            | Disable fallback feature for public packages                                         | false                                 |
 | public.registry                            | Public bower registry's url                                                          | http://bower.herokuapp.com/packages/  |
 | public.registryFile                        | File for persisting public packages (must be a valid json)                           | ./bowerRepositoryPublic.json          |
@@ -152,7 +154,8 @@ Must be a valid JSON
 | repositoryCache.(svn, git).protocol        | Protocol the mirrored repositories will use                                          | git, svn, https, http                 |
 | repositoryCache.(svn, git).publicAccessURL | Public address to access repository cache (useful if repository is behind an apache) | null                                  |
 | repositoryCache.(svn, git).cacheDirectory  | Directory where the public repository cache will save repositories                   | ./svnRepoCache, ./gitRepoCache        |
-| repositoryCache.(svn, git).refreshTimeout  | Time to wai between repository cache refresh (minutes)                               | 10 minutes                            |
+| repositoryCache.(svn, git).refreshTimeout  | Time to wait between repository cache refresh (minutes)                              | 10 minutes                            |
+| repositoryCache.(svn, git).refreshDisabled | Disable automatic updates of the cached repository source code                       | false                                 |
 | repositoryCache.(svn, git).parameters.X    | Custom parameters for git-daemon and svnserve                                        | undefined                             |
 | proxySettings.enabled                      | Enable the proxy, use the proxy to call the bower remote repo                        | false                                 |
 | proxySettings.host                         | Proxy host                                                                           | proxy                                 |

--- a/bower.conf.json
+++ b/bower.conf.json
@@ -26,6 +26,7 @@
             "port": 6789,
             "protocol": "git",
             "publicAccessURL": null,
+            "refreshDisabled": false,
             "refreshTimeout": 10,
             "parameters": {
                 "timeout": 60000,
@@ -39,6 +40,7 @@
             "port": 7891,
             "protocol": "svn",
             "publicAccessURL": null,
+            "refreshDisabled": false,
             "refreshTimeout": 10
         }
     },

--- a/lib/infrastructure/configurationManager.js
+++ b/lib/infrastructure/configurationManager.js
@@ -58,6 +58,7 @@ module.exports = function ConfigurationManager() {
                     hostName: self.config.repositoryCache.svn.host,
                     port: self.config.repositoryCache.svn.port || 7891,
                     protocol: self.config.repositoryCache.svn.protocol || 'svn',
+                    refreshDisabled: self.config.repositoryCache.svn.refreshDisabled || false, 
                     refreshTimeout: self.config.repositoryCache.svn.refreshTimeout || 10,
                     parameters: self.config.repositoryCache.svn.parameters
                 };
@@ -70,6 +71,7 @@ module.exports = function ConfigurationManager() {
                     publicAccessURL: self.config.repositoryCache.git.publicAccessURL || null,
                     port: self.config.repositoryCache.git.port || 6789,
                     protocol: self.config.repositoryCache.git.protocol || 'git',
+                    refreshDisabled: self.config.repositoryCache.git.refreshDisabled || false,
                     refreshTimeout: self.config.repositoryCache.git.refreshTimeout || 10,
                     parameters: self.config.repositoryCache.git.parameters
                 };

--- a/lib/service/repoCaches/gitRepoCache.js
+++ b/lib/service/repoCaches/gitRepoCache.js
@@ -18,7 +18,12 @@ module.exports = function GitRepoCache(options) {
             .then(_checkGitInstalled)
             .then(function() {
                 return new Promise(function(resolve) {
-                    setInterval(_getLatestForRepos, options.refreshTimeout * 60 * 1000);
+                    if (options.refreshDisabled) {
+                        logger.log('Refresh of cached Git repositories is disabled');
+                    }
+                    else {
+                        setInterval(_getLatestForRepos, options.refreshTimeout * 60 * 1000);
+                    }
                     resolve();
                 });
             })

--- a/lib/service/repoCaches/svnRepoCache.js
+++ b/lib/service/repoCaches/svnRepoCache.js
@@ -16,7 +16,12 @@ module.exports = function SvnRepoCache(options) {
         return _createDirectory(options.repoCacheRoot)
             .then(_checkSvnInstalled)
             .then(function() {
-                setInterval(_getLatestForRepos, options.refreshTimeout * 60 * 1000);
+                if (options.refreshDisabled) {
+                    logger.log('Refresh of cached SVN repositories is disabled');
+                }
+                else {
+                    setInterval(_getLatestForRepos, options.refreshTimeout * 60 * 1000);
+                }
             })
             .then(_startSvnDaemon)
             .catch(function(err) {


### PR DESCRIPTION
The `refreshDisabled` setting allows for control over when the `private-bower` server actually calls out to the public registry for cached repositories. When `refreshDisabled` is true for a specific repository, we require that all updates to the repository cache must be performed manually. The default behaviour is to treat the value as `false`, which maintains existing compatibility.

The feature can be used in situations where outgoing connections are restricted and/or need to be managed. (The most specific use case is for situations where `private-bower` does not have internet access except when ports are explicitly opened by system admins.)