### PR TITLE
fix issue #241: no required properties in config file

### DIFF
--- a/lib/infrastructure/configurationManager.js
+++ b/lib/infrastructure/configurationManager.js
@@ -41,7 +41,7 @@ module.exports = function ConfigurationManager() {
 
             self.config.public = self.config.public || {};
 
-            self.config.public.registryFile = getRelativeFilePath(configFile.public.registryFile || './bowerRepositoryPublic.json');
+            self.config.public.registryFile = getRelativeFilePath(configFile.public && configFile.public.registryFile || './bowerRepositoryPublic.json');
             self.config.public.registry = self.config.public.registry || 'https://bower.herokuapp.com/packages';
 
             self.config.public.whitelist = self.config.public.whitelist || [];
@@ -51,6 +51,7 @@ module.exports = function ConfigurationManager() {
             self.config.public.blacklist.enabled = !!self.config.public.blacklist.length;
 
             self.config.repoCacheOptions = {};
+            self.config.repositoryCache = self.config.repositoryCache || {};
 
             if(self.config.repositoryCache.svn && self.config.repositoryCache.svn.enabled) {
                 self.config.repoCacheOptions.svn = {


### PR DESCRIPTION
Fix issue #241 (closed but not resolved).

I just prevented exceptions while trying to get properties of non existent objects.
Now you can have an empty object as config JSON, like empty.json:
`{}`
And do:
`private-bower --config emtpy.json`

And it just works as expected.